### PR TITLE
認証にPunditの導入と、独自の認証機構を削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,4 +68,6 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'webpacker', github: 'rails/webpacker'
 
+# for Authorize
 gem 'devise'
+gem 'pundit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
       ast (~> 2.4.1)
     public_suffix (4.0.5)
     puma (3.12.6)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     rack (2.2.3)
     rack-proxy (0.6.5)
       rack
@@ -253,6 +255,7 @@ DEPENDENCIES
   letter_opener_web
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.12)
+  pundit
   rails (~> 5.2.4, >= 5.2.4.1)
   rubocop
   sass-rails (~> 5.0)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,10 +3,12 @@
 module Admin
   class UsersController < ApplicationController
     before_action :set_user, only: %i[show edit update destroy]
-    before_action :check_user_role
+    before_action :check_authorize
 
     def index
       @users = User.all
+
+      redirect_to home_index_url unless @users.index
     end
 
     def show; end
@@ -50,6 +52,18 @@ module Admin
 
     def admin_access_denine
       redirect_to home_index_url
+    end
+
+    def check_authorize
+      return authorize @user if @user.present?
+
+      authorize :user
+    end
+
+    def authorize(record, query = nil, policy_class: nil)
+      return super([:admin, record].flatten, query) if policy_class.nil?
+
+      super(record, query, policy_class: policy_class)
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,8 +7,6 @@ module Admin
 
     def index
       @users = User.all
-
-      redirect_to home_index_url unless @users.index
     end
 
     def show; end
@@ -43,15 +41,6 @@ module Admin
 
     def user_params
       params.require(:user).permit(:id, :email)
-    end
-
-    def check_user_role
-      return admin_access_denine unless user_signed_in?
-      return admin_access_denine unless User::ADMMIN_USER_IDS.include?(current_user.id)
-    end
-
-    def admin_access_denine
-      redirect_to home_index_url
     end
 
     def check_authorize

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include Pundit
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  ADMMIN_USER_IDS = [1].freeze
 
   has_many :game
   enum user_type: { normal: 1, admin: 10 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   ADMMIN_USER_IDS = [1].freeze
 
   has_many :game
+  enum user_type: { normal: 1, admin: 10 }
 end

--- a/app/policies/admin/base_policy.rb
+++ b/app/policies/admin/base_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BasePolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  private
+    def user_type_admin?
+      @user.admin?
+    end
+end

--- a/app/policies/admin/base_policy.rb
+++ b/app/policies/admin/base_policy.rb
@@ -9,7 +9,8 @@ class BasePolicy
   end
 
   private
-    def user_type_admin?
-      @user.admin?
-    end
+
+  def user_type_admin?
+    @user.admin?
+  end
 end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -1,11 +1,25 @@
 # frozen_string_literal: true
 
-class UserPolicy < ApplicationPolicy
-  def index?
-    false unless user.admin?
-  end
+module Admin
+  class UserPolicy < BasePolicy
+    def index?
+      user_type_admin?
+    end
 
-  def show?
-    false unless user.admin?
+    def show?
+      user_type_admin?
+    end
+
+    def edit?
+      user_type_admin?
+    end
+
+    def update?
+      user_type_admin?
+    end
+
+    def destroy?
+      user_type_admin?
+    end
   end
 end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UserPolicy < ApplicationPolicy
+  def index?
+    false unless user.admin?
+  end
+
+  def show?
+    false unless user.admin?
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 class ApplicationPolicy
   attr_reader :user, :record
 

--- a/db/migrate/20200810120812_add_user_id_to_game.rb
+++ b/db/migrate/20200810120812_add_user_id_to_game.rb
@@ -1,4 +1,4 @@
-class AddUserTypeToUser < ActiveRecord::Migration[5.2]
+class AddUserIdToGame < ActiveRecord::Migration[5.2]
   def change
     add_reference :games, :user, foreign_key: true
   end

--- a/db/migrate/20200810143751_add_type_to_user.rb
+++ b/db/migrate/20200810143751_add_type_to_user.rb
@@ -1,0 +1,5 @@
+class AddTypeToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :user_type, :integer, default: 1, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_10_120812) do
+ActiveRecord::Schema.define(version: 2020_08_10_143751) do
 
   create_table "actnesses", force: :cascade do |t|
     t.integer "ball_type"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2020_08_10_120812) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_type", default: 1, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 目的
Punditの導入

## 変更内容
Punditの導入。
adminディレクトリ以下を `user_type = admin(num: 10)` で認証するように変更。
ベタ書きだったadmin権限のidや関連の認証機構を削除

## 外部 URL


