### PR TITLE
game_controllerに不足していたパラメーターを追加

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -72,6 +72,6 @@ class GamesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def game_params
-    params.require(:game).permit(:date)
+    params.require(:game).permit(:date, :user_id)
   end
 end


### PR DESCRIPTION
## 目的
表題の通り

## 変更内容
game_controllerに:user_idのパラメーターが不足していて新規作成などができなくなっていたので、これを修正


## 外部 URL


